### PR TITLE
Add Continuations.foreach() and Continuations.sequence() overload

### DIFF
--- a/src/main/kotlin/dev/frozenmilk/dairy/mercurial/continuations/Continuations.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/mercurial/continuations/Continuations.kt
@@ -504,6 +504,15 @@ object Continuations {
     }
 
     //
+    // foreach
+    //
+
+    @JvmStatic
+    fun <T> foreach(items: Collection<T>, block: (T) -> Closure) = if (items.isEmpty()) noop()
+    else if (items.size == 1) block(items.first())
+    else sequence(items.map(block))
+
+    //
     // panic!
     //
 

--- a/src/main/kotlin/dev/frozenmilk/dairy/mercurial/continuations/Continuations.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/mercurial/continuations/Continuations.kt
@@ -111,6 +111,9 @@ object Continuations {
         closures.foldRight(k) { closure, k -> closure.close(name, k) }
     }
 
+    @JvmStatic
+    fun sequence(closures: Collection<Closure>) = sequence(*closures.toTypedArray())
+
     //
     // if?
     //


### PR DESCRIPTION
- `Continuations.foreach()` takes a `Collection<T>` and a `(T) -> Closure` and returns a sequence of the closure for each item in the collection.
- `Continuations.sequence()` now can take a `Collection<Closure>` instead of a `vararg Closure`.