### PR TITLE
Fix always true popFiber check in Mutex.kt and update SUBSCHEDULE logic to not unravel canceled fibers

### DIFF
--- a/src/main/kotlin/dev/frozenmilk/dairy/mercurial/continuations/Fiber.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/mercurial/continuations/Fiber.kt
@@ -170,7 +170,14 @@ class Fiber(private var k: Continuation) {
         }
 
         @JvmStatic
-        fun SUBSCHEDULE(child: Fiber) = if (currentFiber.state === State.CANCELLED) CANCEL(child)
-        else UNRAVEL(child)
+        fun SUBSCHEDULE(child: Fiber) = if (currentFiber.state === State.CANCELLED) {
+            CANCEL(child)
+        } else if (child.state !== State.CANCELLED) {
+            UNRAVEL(child)
+        } else {
+            // The child is already canceled
+            // The parent should then see that it's canceled
+            Unit
+        }
     }
 }

--- a/src/main/kotlin/dev/frozenmilk/dairy/mercurial/continuations/mutexes/Mutex.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/mercurial/continuations/mutexes/Mutex.kt
@@ -40,7 +40,7 @@ class Mutex<PRIORITY, T>(
     }
 
     internal fun popFiber(fiber: Fiber) {
-        if (callstack?.car != fiber) return
+        if (callstack?.car?.fiber != fiber) return
         val cons = checkNotNull(callstack) { "attempted to pop fiber off an empty callstack" }
         callstack = cons.cdr
         Cons.drop(cons)


### PR DESCRIPTION
Fixes the check in popFiber where it compares a Frame to a Fiber, resulting in the frame never being popped. Also changes the SUBSCHEDULE logic to not unravel canceled children, which kept giving me the `java.lang.IllegalStateException: attempted to UNRAVEL cancelled continuation` error.

I've tested it with a [simple mutex testing program](https://github.com/Huskyteers19516/Decode/blob/24cd2570ed1ae8953ea0c2ac0a833f7b5ed94814/TeamCodeD/src/main/java/org/firstinspires/ftc/teamcode/opmode/MutexTester.kt) that was not working previous to these changes, as well as a [teleop](https://github.com/Huskyteers19516/Decode/blob/24cd2570ed1ae8953ea0c2ac0a833f7b5ed94814/TeamCodeD/src/main/java/org/firstinspires/ftc/teamcode/opmode/HuskyTeleOp.kt) I had that was not working previously, which includes acquiring the mutex inside a mutex scope, which also works correctly now.

I don't believe the update to the SUBSCHEDULE function should affect anything, but I am not entirely sure as I have not tested every single case with the function.